### PR TITLE
bug fix between docker versions

### DIFF
--- a/gcbillanalyzer/Dockerfile
+++ b/gcbillanalyzer/Dockerfile
@@ -1,3 +1,3 @@
 FROM java
-ADD *.jar /opt
+ADD *.jar /opt/
 CMD /usr/bin/java -jar /opt/gcbillanalyzer-1.0.0-jar-with-dependencies.jar


### PR DESCRIPTION
We found that in older versions of docker the line ADD *.jar /opt worked fine. in later versions this line needed a trailing slash ADD *.jar /opt/